### PR TITLE
Add server options to configure socket.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ io.on("connection", function(socket) {
 ### hapio options
 
  * `connectionLabel`: (*Not required/Defaults to an empty string*) Connection's label on which socket io will be attached to
+ * `serverOptions`: (*Not required/Defaults to an empty object*) Options to pass to socket.io's constructor.
 
 
 ### A great idea?

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,8 @@
 
 var _ = require('underscore'),
     defaultOptions = {
-        connectionLabel: ''
+        connectionLabel: '',
+        serverOptions: {}
     };
 
 exports.register = function (server, options, next) {
@@ -20,7 +21,7 @@ exports.register = function (server, options, next) {
         listener = server.connections[0].listener;
     }
 
-    io = require('socket.io')(listener);
+    io = require('socket.io')(listener, options.serverOptions);
     server.expose('io', io);
 
     return next();


### PR DESCRIPTION
Currently there's no way of passing server options (i.e. `path` or `serveClient`) to socket.io's constructor. This PR simply adds an additional `serverOptions` key in the options object to fix that limitation.